### PR TITLE
Fix test imports and add QA tooling

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -1,23 +1,38 @@
 #!/usr/bin/env python3
 import argparse
+import importlib
 import json
 import os
 import sys
 from dataclasses import dataclass
-from typing import List, Optional
-
-# Import config early to trigger optional .env loading via python-dotenv
-try:
-    from src import config as _config  # noqa: F401
-except Exception:
-    _config = None  # OS env will still be used by providers
-
-try:
-    import requests  # Only used for Ollama; stdlib alternative possible but requests is common
-except Exception:
-    requests = None
+from typing import Any, List, Optional, cast
 
 from src.providers.qwen_provider import QwenProvider
+
+# Import config early to trigger optional .env loading via python-dotenv
+from types import ModuleType
+
+
+def _load_config_module() -> ModuleType | None:
+    try:
+        from src import config as config_module  # noqa: F401
+
+        return config_module
+    except Exception:
+        return None
+
+
+CONFIG_MODULE: ModuleType | None = _load_config_module()
+
+
+def _load_requests_module() -> ModuleType | None:
+    try:
+        return cast(ModuleType, importlib.import_module("requests"))
+    except Exception:
+        return None
+
+
+REQUESTS: ModuleType | None = _load_requests_module()
 
 
 @dataclass
@@ -27,11 +42,24 @@ class Message:
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Minimal chatbot CLI supporting mock, openai, and ollama providers.")
-    p.add_argument("--provider", choices=["mock", "openai", "ollama", "qwen"], default="mock", help="Backend provider.")
-    p.add_argument("--model", default=None, help="Model name (required for openai/ollama). Examples: gpt-4o-mini, qwen2.5:7b-instruct")
+    p = argparse.ArgumentParser(
+        description="Minimal chatbot CLI supporting mock, openai, and ollama providers."
+    )
+    p.add_argument(
+        "--provider",
+        choices=["mock", "openai", "ollama", "qwen"],
+        default="mock",
+        help="Backend provider.",
+    )
+    p.add_argument(
+        "--model",
+        default=None,
+        help="Model name (required for openai/ollama). Examples: gpt-4o-mini, qwen2.5:7b-instruct",
+    )
     p.add_argument("--once", default=None, help="Send a single prompt and exit.")
-    p.add_argument("--system", default="You are a helpful assistant.", help="System prompt.")
+    p.add_argument(
+        "--system", default="You are a helpful assistant.", help="System prompt."
+    )
     return p.parse_args()
 
 
@@ -78,14 +106,19 @@ def run_inference(provider: str, model: Optional[str], messages: List[Message]) 
 
 # --- Providers ---
 
+
 def mock_infer(messages: List[Message]) -> str:
-    user_messages = [m.content.strip() for m in messages if m.role == "user" and m.content.strip()]
+    user_messages = [
+        m.content.strip() for m in messages if m.role == "user" and m.content.strip()
+    ]
     if not user_messages:
-        return "[mock] Hello! I'm the built-in assistant. Ask me anything and we'll chat."
+        return (
+            "[mock] Hello! I'm the built-in assistant. Ask me anything and we'll chat."
+        )
 
     last_user = user_messages[-1]
     previous = user_messages[-2] if len(user_messages) > 1 else None
-    normalized = last_user.strip().lower().rstrip('!.?')
+    normalized = last_user.strip().lower().rstrip("!.?")
 
     farewells = {"bye", "goodbye", "see you", "see ya"}
     if normalized in farewells:
@@ -100,11 +133,14 @@ def mock_infer(messages: List[Message]) -> str:
     response_parts.append(f'I hear you saying "{last_user}".')
 
     if last_user.endswith("?"):
-        response_parts.append("I can't access real data, but I'd love to hear your thoughts.")
+        response_parts.append(
+            "I can't access real data, but I'd love to hear your thoughts."
+        )
     else:
         response_parts.append("Tell me more so we can keep the conversation going.")
 
     return " ".join(response_parts)
+
 
 # Minimal provider class so the registry is valid.
 class MockProvider:
@@ -117,7 +153,9 @@ def openai_infer(model: Optional[str], messages: List[Message]) -> str:
     try:
         from openai import OpenAI
     except Exception as e:
-        raise RuntimeError("OpenAI provider requested but the 'openai' package is not installed. Run: pip install -r requirements.txt") from e
+        raise RuntimeError(
+            "OpenAI provider requested but the 'openai' package is not installed. Run: pip install -r requirements.txt"
+        ) from e
 
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
@@ -126,13 +164,21 @@ def openai_infer(model: Optional[str], messages: List[Message]) -> str:
         raise RuntimeError("--model is required for --provider openai.")
 
     base_url = os.getenv("OPENAI_BASE_URL")
-    client = OpenAI(api_key=api_key, base_url=base_url) if base_url else OpenAI(api_key=api_key)
+    client = (
+        OpenAI(api_key=api_key, base_url=base_url)
+        if base_url
+        else OpenAI(api_key=api_key)
+    )
 
     chat_messages = [{"role": m.role, "content": m.content} for m in messages]
 
     try:
-        resp = client.chat.completions.create(model=model, messages=chat_messages)
-        return resp.choices[0].message.content.strip()
+        resp = client.chat.completions.create(
+            model=model,
+            messages=cast(Any, chat_messages),
+        )
+        content = resp.choices[0].message.content
+        return content.strip() if content else ""
     except Exception as e:
         raise RuntimeError(f"OpenAI API error: {e}")
 
@@ -140,8 +186,10 @@ def openai_infer(model: Optional[str], messages: List[Message]) -> str:
 def ollama_infer(model: Optional[str], messages: List[Message]) -> str:
     if not model:
         raise RuntimeError("--model is required for --provider ollama.")
-    if requests is None:
-        raise RuntimeError("The 'requests' package is required for Ollama provider. Run: pip install requests")
+    if REQUESTS is None:
+        raise RuntimeError(
+            "The 'requests' package is required for Ollama provider. Run: pip install requests"
+        )
 
     url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434") + "/api/chat"
     payload = {
@@ -150,7 +198,12 @@ def ollama_infer(model: Optional[str], messages: List[Message]) -> str:
         "stream": False,
     }
     try:
-        r = requests.post(url, data=json.dumps(payload), headers={"Content-Type": "application/json"}, timeout=120)
+        r = cast(Any, REQUESTS).post(
+            url,
+            data=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+            timeout=120,
+        )
         r.raise_for_status()
         data = r.json()
         # The exact shape may vary by Ollama version; handle common formats
@@ -165,6 +218,7 @@ def ollama_infer(model: Optional[str], messages: List[Message]) -> str:
     except Exception as e:
         raise RuntimeError(f"Ollama request failed: {e}")
 
+
 def qwen_infer(model: Optional[str], messages: List[Message]) -> str:
     """Call Qwen via OpenRouter using QwenProvider.
 
@@ -173,6 +227,7 @@ def qwen_infer(model: Optional[str], messages: List[Message]) -> str:
     provider = QwenProvider()
     chat_messages = [{"role": m.role, "content": m.content} for m in messages]
     return provider.chat(chat_messages, model_override=model)
+
 
 # Provider registry
 PROVIDERS = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ openai>=1.52.0
 requests>=2.32.0
 pytest>=8.3.3
 python-dotenv>=1.0.1
+pytest-cov>=5.0.0
+types-requests>=2.32.0.20241016
+bandit>=1.7.10

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,10 @@
 # src/config.py
 from pathlib import Path
 import os
+
 try:
     from dotenv import load_dotenv  # pip install python-dotenv
+
     env_file = Path(__file__).resolve().parents[1] / ".env"
     if env_file.exists():
         load_dotenv(env_file)

--- a/src/providers/qwen_provider.py
+++ b/src/providers/qwen_provider.py
@@ -1,33 +1,47 @@
 # src/providers/qwen_provider.py
-"""
-QwenProvider – connects CLI chatbot to Qwen3-4B via OpenRouter API.
-"""
+"""QwenProvider – connects CLI chatbot to Qwen3-4B via OpenRouter API."""
 
 import os
+from types import ModuleType
+from typing import Any, Dict, List
+
 import requests
-from typing import List, Dict, Any
+
 
 # Try to load config to ensure .env is read if available
-try:
-    from src import config as _config
-except Exception:
-    _config = None
+def _load_config_module() -> ModuleType | None:
+    try:
+        from src import config as config_module
+
+        return config_module
+    except Exception:
+        return None
+
+
+CONFIG_MODULE: ModuleType | None = _load_config_module()
+
 
 class QwenProvider:
     def __init__(self):
         # Prefer values from config if available (ensures .env is loaded), else fall back to OS env
-        self.api_key = getattr(_config, "OPENROUTER_API_KEY", None) or os.getenv("OPENROUTER_API_KEY")
-        self.model = getattr(_config, "MODEL_NAME", None) or os.getenv("MODEL_NAME", "qwen/qwen3-4b:free")
+        self.api_key = getattr(CONFIG_MODULE, "OPENROUTER_API_KEY", None) or os.getenv(
+            "OPENROUTER_API_KEY"
+        )
+        self.model = getattr(CONFIG_MODULE, "MODEL_NAME", None) or os.getenv(
+            "MODEL_NAME", "qwen/qwen3-4b:free"
+        )
         self.base_url = "https://openrouter.ai/api/v1/chat/completions"
 
     def chat(self, messages: List[Dict[str, Any]], model_override: str | None = None):
         if not self.api_key:
-            raise RuntimeError("OPENROUTER_API_KEY is not set. Set it in OS env or in a .env file.")
+            raise RuntimeError(
+                "OPENROUTER_API_KEY is not set. Set it in OS env or in a .env file."
+            )
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
-        model = (model_override or self.model)
+        model = model_override or self.model
         payload = {"model": model, "messages": messages}
         resp = requests.post(self.base_url, json=payload, headers=headers, timeout=30)
         resp.raise_for_status()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Test configuration to ensure project root is importable."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure pytest can import the chatbot module by adding a tests-level path shim
- harden provider imports to tolerate missing optional dependencies while keeping type-checking happy
- add coverage, typing stubs, and security tooling to the requirements for the QA pipeline

## Testing
- pip install -r requirements.txt
- pytest
- pytest --cov=chatbot --cov=src
- ruff check
- black --check .
- mypy .
- bandit -r .

------
https://chatgpt.com/codex/tasks/task_e_68e3e79a8c28833084c69b41d341d55c