### PR TITLE
Fix test imports and improve provider typing

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -3,21 +3,35 @@ import argparse
 import json
 import os
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import List, Optional
-
-# Import config early to trigger optional .env loading via python-dotenv
-try:
-    from src import config as _config  # noqa: F401
-except Exception:
-    _config = None  # OS env will still be used by providers
-
-try:
-    import requests  # Only used for Ollama; stdlib alternative possible but requests is common
-except Exception:
-    requests = None
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 from src.providers.qwen_provider import QwenProvider
+
+
+def _maybe_load_config() -> None:
+    """Import config to trigger optional .env loading if python-dotenv is installed."""
+
+    try:
+        from src import config  # noqa: F401
+    except Exception:
+        # OS environment variables will still be available.
+        return
+
+
+_maybe_load_config()
+
+try:
+    import requests as _requests  # Only used for Ollama; stdlib alternative possible but requests is common
+except Exception:
+    _requests = None  # type: ignore[assignment]
+
+requests: ModuleType | None = cast(ModuleType | None, _requests)
+
+if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletionMessageParam
 
 
 @dataclass
@@ -27,11 +41,24 @@ class Message:
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Minimal chatbot CLI supporting mock, openai, and ollama providers.")
-    p.add_argument("--provider", choices=["mock", "openai", "ollama", "qwen"], default="mock", help="Backend provider.")
-    p.add_argument("--model", default=None, help="Model name (required for openai/ollama). Examples: gpt-4o-mini, qwen2.5:7b-instruct")
+    p = argparse.ArgumentParser(
+        description="Minimal chatbot CLI supporting mock, openai, and ollama providers."
+    )
+    p.add_argument(
+        "--provider",
+        choices=["mock", "openai", "ollama", "qwen"],
+        default="mock",
+        help="Backend provider.",
+    )
+    p.add_argument(
+        "--model",
+        default=None,
+        help="Model name (required for openai/ollama). Examples: gpt-4o-mini, qwen2.5:7b-instruct",
+    )
     p.add_argument("--once", default=None, help="Send a single prompt and exit.")
-    p.add_argument("--system", default="You are a helpful assistant.", help="System prompt.")
+    p.add_argument(
+        "--system", default="You are a helpful assistant.", help="System prompt."
+    )
     return p.parse_args()
 
 
@@ -78,14 +105,19 @@ def run_inference(provider: str, model: Optional[str], messages: List[Message]) 
 
 # --- Providers ---
 
+
 def mock_infer(messages: List[Message]) -> str:
-    user_messages = [m.content.strip() for m in messages if m.role == "user" and m.content.strip()]
+    user_messages = [
+        m.content.strip() for m in messages if m.role == "user" and m.content.strip()
+    ]
     if not user_messages:
-        return "[mock] Hello! I'm the built-in assistant. Ask me anything and we'll chat."
+        return (
+            "[mock] Hello! I'm the built-in assistant. Ask me anything and we'll chat."
+        )
 
     last_user = user_messages[-1]
     previous = user_messages[-2] if len(user_messages) > 1 else None
-    normalized = last_user.strip().lower().rstrip('!.?')
+    normalized = last_user.strip().lower().rstrip("!.?")
 
     farewells = {"bye", "goodbye", "see you", "see ya"}
     if normalized in farewells:
@@ -100,11 +132,14 @@ def mock_infer(messages: List[Message]) -> str:
     response_parts.append(f'I hear you saying "{last_user}".')
 
     if last_user.endswith("?"):
-        response_parts.append("I can't access real data, but I'd love to hear your thoughts.")
+        response_parts.append(
+            "I can't access real data, but I'd love to hear your thoughts."
+        )
     else:
         response_parts.append("Tell me more so we can keep the conversation going.")
 
     return " ".join(response_parts)
+
 
 # Minimal provider class so the registry is valid.
 class MockProvider:
@@ -117,7 +152,9 @@ def openai_infer(model: Optional[str], messages: List[Message]) -> str:
     try:
         from openai import OpenAI
     except Exception as e:
-        raise RuntimeError("OpenAI provider requested but the 'openai' package is not installed. Run: pip install -r requirements.txt") from e
+        raise RuntimeError(
+            "OpenAI provider requested but the 'openai' package is not installed. Run: pip install -r requirements.txt"
+        ) from e
 
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
@@ -126,13 +163,23 @@ def openai_infer(model: Optional[str], messages: List[Message]) -> str:
         raise RuntimeError("--model is required for --provider openai.")
 
     base_url = os.getenv("OPENAI_BASE_URL")
-    client = OpenAI(api_key=api_key, base_url=base_url) if base_url else OpenAI(api_key=api_key)
+    client = (
+        OpenAI(api_key=api_key, base_url=base_url)
+        if base_url
+        else OpenAI(api_key=api_key)
+    )
 
-    chat_messages = [{"role": m.role, "content": m.content} for m in messages]
+    chat_messages = cast(
+        List["ChatCompletionMessageParam"],
+        [{"role": m.role, "content": m.content} for m in messages],
+    )
 
     try:
-        resp = client.chat.completions.create(model=model, messages=chat_messages)
-        return resp.choices[0].message.content.strip()
+        resp = client.chat.completions.create(
+            model=model, messages=cast(Iterable[Any], chat_messages)
+        )
+        content = resp.choices[0].message.content or ""
+        return content.strip()
     except Exception as e:
         raise RuntimeError(f"OpenAI API error: {e}")
 
@@ -141,7 +188,9 @@ def ollama_infer(model: Optional[str], messages: List[Message]) -> str:
     if not model:
         raise RuntimeError("--model is required for --provider ollama.")
     if requests is None:
-        raise RuntimeError("The 'requests' package is required for Ollama provider. Run: pip install requests")
+        raise RuntimeError(
+            "The 'requests' package is required for Ollama provider. Run: pip install requests"
+        )
 
     url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434") + "/api/chat"
     payload = {
@@ -150,7 +199,12 @@ def ollama_infer(model: Optional[str], messages: List[Message]) -> str:
         "stream": False,
     }
     try:
-        r = requests.post(url, data=json.dumps(payload), headers={"Content-Type": "application/json"}, timeout=120)
+        r = requests.post(
+            url,
+            data=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+            timeout=120,
+        )
         r.raise_for_status()
         data = r.json()
         # The exact shape may vary by Ollama version; handle common formats
@@ -165,6 +219,7 @@ def ollama_infer(model: Optional[str], messages: List[Message]) -> str:
     except Exception as e:
         raise RuntimeError(f"Ollama request failed: {e}")
 
+
 def qwen_infer(model: Optional[str], messages: List[Message]) -> str:
     """Call Qwen via OpenRouter using QwenProvider.
 
@@ -173,6 +228,7 @@ def qwen_infer(model: Optional[str], messages: List[Message]) -> str:
     provider = QwenProvider()
     chat_messages = [{"role": m.role, "content": m.content} for m in messages]
     return provider.chat(chat_messages, model_override=model)
+
 
 # Provider registry
 PROVIDERS = {

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,10 @@
 # src/config.py
 from pathlib import Path
 import os
+
 try:
     from dotenv import load_dotenv  # pip install python-dotenv
+
     env_file = Path(__file__).resolve().parents[1] / ".env"
     if env_file.exists():
         load_dotenv(env_file)

--- a/src/providers/qwen_provider.py
+++ b/src/providers/qwen_provider.py
@@ -4,30 +4,42 @@ QwenProvider – connects CLI chatbot to Qwen3-4B via OpenRouter API.
 """
 
 import os
-import requests
-from typing import List, Dict, Any
+from types import ModuleType
+from typing import Any, Dict, List, cast
 
-# Try to load config to ensure .env is read if available
+import requests
+
 try:
-    from src import config as _config
+    from src import config as _config_module
 except Exception:
-    _config = None
+    _CONFIG: ModuleType | None = None
+else:
+    _CONFIG = cast(ModuleType, _config_module)
+
 
 class QwenProvider:
     def __init__(self):
         # Prefer values from config if available (ensures .env is loaded), else fall back to OS env
-        self.api_key = getattr(_config, "OPENROUTER_API_KEY", None) or os.getenv("OPENROUTER_API_KEY")
-        self.model = getattr(_config, "MODEL_NAME", None) or os.getenv("MODEL_NAME", "qwen/qwen3-4b:free")
+        self.api_key = getattr(_CONFIG, "OPENROUTER_API_KEY", None) or os.getenv(
+            "OPENROUTER_API_KEY"
+        )
+        self.model = getattr(_CONFIG, "MODEL_NAME", None) or os.getenv(
+            "MODEL_NAME", "qwen/qwen3-4b:free"
+        )
         self.base_url = "https://openrouter.ai/api/v1/chat/completions"
 
-    def chat(self, messages: List[Dict[str, Any]], model_override: str | None = None):
+    def chat(
+        self, messages: List[Dict[str, Any]], model_override: str | None = None
+    ) -> str:
         if not self.api_key:
-            raise RuntimeError("OPENROUTER_API_KEY is not set. Set it in OS env or in a .env file.")
+            raise RuntimeError(
+                "OPENROUTER_API_KEY is not set. Set it in OS env or in a .env file."
+            )
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
-        model = (model_override or self.model)
+        model = model_override or self.model
         payload = {"model": model, "messages": messages}
         resp = requests.post(self.base_url, json=payload, headers=headers, timeout=30)
         resp.raise_for_status()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Test configuration helpers for pytest.
+
+Ensures the project root is importable when running tests so modules like
+``chatbot`` can be imported without installing the package.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add a pytest conftest helper so the top-level chatbot module imports during tests
- harden typing-aware paths for OpenAI and Qwen providers, including safer request handling
- formalize optional config loading to avoid runtime side effects during analysis

## Testing
- pip install -r requirements.txt
- pytest -q
- ruff check
- black --check .
- mypy --hide-error-codes chatbot.py src/providers/qwen_provider.py src/config.py tests/conftest.py
- bandit -r . -q

------
https://chatgpt.com/codex/tasks/task_e_68e3e7a9afd08330b5d8bbb4f54b4bf8