### PR TITLE
Improve provider coverage and typing guards

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -4,18 +4,25 @@ import json
 import os
 import sys
 from dataclasses import dataclass
+from types import ModuleType
 from typing import List, Optional
 
 # Import config early to trigger optional .env loading via python-dotenv
+_config_module: ModuleType | None
 try:
-    from src import config as _config  # noqa: F401
+    from src import config as _config_module  # noqa: F401
 except Exception:
-    _config = None  # OS env will still be used by providers
+    _config_module = None  # OS env will still be used by providers
 
+_config = _config_module
+
+_requests_module: ModuleType | None
 try:
-    import requests  # Only used for Ollama; stdlib alternative possible but requests is common
+    import requests as _requests_module  # Only used for Ollama; stdlib alternative possible but requests is common
 except Exception:
-    requests = None
+    _requests_module = None
+
+requests = _requests_module
 
 from src.providers.qwen_provider import QwenProvider
 
@@ -27,11 +34,24 @@ class Message:
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Minimal chatbot CLI supporting mock, openai, and ollama providers.")
-    p.add_argument("--provider", choices=["mock", "openai", "ollama", "qwen"], default="mock", help="Backend provider.")
-    p.add_argument("--model", default=None, help="Model name (required for openai/ollama). Examples: gpt-4o-mini, qwen2.5:7b-instruct")
+    p = argparse.ArgumentParser(
+        description="Minimal chatbot CLI supporting mock, openai, and ollama providers."
+    )
+    p.add_argument(
+        "--provider",
+        choices=["mock", "openai", "ollama", "qwen"],
+        default="mock",
+        help="Backend provider.",
+    )
+    p.add_argument(
+        "--model",
+        default=None,
+        help="Model name (required for openai/ollama). Examples: gpt-4o-mini, qwen2.5:7b-instruct",
+    )
     p.add_argument("--once", default=None, help="Send a single prompt and exit.")
-    p.add_argument("--system", default="You are a helpful assistant.", help="System prompt.")
+    p.add_argument(
+        "--system", default="You are a helpful assistant.", help="System prompt."
+    )
     return p.parse_args()
 
 
@@ -78,14 +98,19 @@ def run_inference(provider: str, model: Optional[str], messages: List[Message]) 
 
 # --- Providers ---
 
+
 def mock_infer(messages: List[Message]) -> str:
-    user_messages = [m.content.strip() for m in messages if m.role == "user" and m.content.strip()]
+    user_messages = [
+        m.content.strip() for m in messages if m.role == "user" and m.content.strip()
+    ]
     if not user_messages:
-        return "[mock] Hello! I'm the built-in assistant. Ask me anything and we'll chat."
+        return (
+            "[mock] Hello! I'm the built-in assistant. Ask me anything and we'll chat."
+        )
 
     last_user = user_messages[-1]
     previous = user_messages[-2] if len(user_messages) > 1 else None
-    normalized = last_user.strip().lower().rstrip('!.?')
+    normalized = last_user.strip().lower().rstrip("!.?")
 
     farewells = {"bye", "goodbye", "see you", "see ya"}
     if normalized in farewells:
@@ -100,11 +125,14 @@ def mock_infer(messages: List[Message]) -> str:
     response_parts.append(f'I hear you saying "{last_user}".')
 
     if last_user.endswith("?"):
-        response_parts.append("I can't access real data, but I'd love to hear your thoughts.")
+        response_parts.append(
+            "I can't access real data, but I'd love to hear your thoughts."
+        )
     else:
         response_parts.append("Tell me more so we can keep the conversation going.")
 
     return " ".join(response_parts)
+
 
 # Minimal provider class so the registry is valid.
 class MockProvider:
@@ -117,7 +145,9 @@ def openai_infer(model: Optional[str], messages: List[Message]) -> str:
     try:
         from openai import OpenAI
     except Exception as e:
-        raise RuntimeError("OpenAI provider requested but the 'openai' package is not installed. Run: pip install -r requirements.txt") from e
+        raise RuntimeError(
+            "OpenAI provider requested but the 'openai' package is not installed. Run: pip install -r requirements.txt"
+        ) from e
 
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
@@ -126,7 +156,11 @@ def openai_infer(model: Optional[str], messages: List[Message]) -> str:
         raise RuntimeError("--model is required for --provider openai.")
 
     base_url = os.getenv("OPENAI_BASE_URL")
-    client = OpenAI(api_key=api_key, base_url=base_url) if base_url else OpenAI(api_key=api_key)
+    client = (
+        OpenAI(api_key=api_key, base_url=base_url)
+        if base_url
+        else OpenAI(api_key=api_key)
+    )
 
     chat_messages = [{"role": m.role, "content": m.content} for m in messages]
 
@@ -141,7 +175,9 @@ def ollama_infer(model: Optional[str], messages: List[Message]) -> str:
     if not model:
         raise RuntimeError("--model is required for --provider ollama.")
     if requests is None:
-        raise RuntimeError("The 'requests' package is required for Ollama provider. Run: pip install requests")
+        raise RuntimeError(
+            "The 'requests' package is required for Ollama provider. Run: pip install requests"
+        )
 
     url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434") + "/api/chat"
     payload = {
@@ -150,7 +186,12 @@ def ollama_infer(model: Optional[str], messages: List[Message]) -> str:
         "stream": False,
     }
     try:
-        r = requests.post(url, data=json.dumps(payload), headers={"Content-Type": "application/json"}, timeout=120)
+        r = requests.post(
+            url,
+            data=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+            timeout=120,
+        )
         r.raise_for_status()
         data = r.json()
         # The exact shape may vary by Ollama version; handle common formats
@@ -165,6 +206,7 @@ def ollama_infer(model: Optional[str], messages: List[Message]) -> str:
     except Exception as e:
         raise RuntimeError(f"Ollama request failed: {e}")
 
+
 def qwen_infer(model: Optional[str], messages: List[Message]) -> str:
     """Call Qwen via OpenRouter using QwenProvider.
 
@@ -173,6 +215,7 @@ def qwen_infer(model: Optional[str], messages: List[Message]) -> str:
     provider = QwenProvider()
     chat_messages = [{"role": m.role, "content": m.content} for m in messages]
     return provider.chat(chat_messages, model_override=model)
+
 
 # Provider registry
 PROVIDERS = {

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,10 @@
 # src/config.py
 from pathlib import Path
 import os
+
 try:
     from dotenv import load_dotenv  # pip install python-dotenv
+
     env_file = Path(__file__).resolve().parents[1] / ".env"
     if env_file.exists():
         load_dotenv(env_file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Test configuration for ensuring package imports succeed."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the project root is available for importing the chatbot module when
+# pytest runs from a different working directory (e.g., coverage runs).
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,6 +1,36 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
-from chatbot import Message, mock_infer, run_inference
+import chatbot
+from chatbot import (
+    Message,
+    chat_loop,
+    mock_infer,
+    openai_infer,
+    ollama_infer,
+    parse_args,
+    qwen_infer,
+    run_inference,
+    run_once,
+)
+from src.providers import qwen_provider
+
+
+@pytest.fixture(autouse=True)
+def reset_env(monkeypatch):
+    """Clear provider-related environment variables between tests."""
+    for key in [
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENROUTER_API_KEY",
+        "MODEL_NAME",
+        "OLLAMA_BASE_URL",
+    ]:
+        monkeypatch.delenv(key, raising=False)
 
 
 def test_mock_infer_without_user_messages():
@@ -40,3 +70,216 @@ def test_run_inference_dispatches_to_mock(monkeypatch):
 def test_run_inference_rejects_unknown_provider():
     with pytest.raises(ValueError):
         run_inference("unknown", None, [])
+
+
+def test_parse_args_defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["chatbot.py"])
+    args = parse_args()
+    assert args.provider == "mock"
+    assert args.system == "You are a helpful assistant."
+    assert args.once is None
+
+
+def test_chat_loop_handles_conversation(monkeypatch, capsys):
+    responses = iter(["reply"])
+    inputs = iter(["", "Hello", "/exit"])
+
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr(
+        "chatbot.run_inference", lambda provider, model, messages: next(responses)
+    )
+
+    chat_loop("mock", "model-x", "system prompt")
+
+    out = capsys.readouterr().out
+    assert "Provider: mock" in out
+    assert "Model: model-x" in out
+    assert "Bot: reply" in out
+    assert "Bye!" in out
+
+
+def test_run_once_executes_single_prompt(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "chatbot.run_inference", lambda provider, model, messages: "single reply"
+    )
+    run_once("mock", "model-x", "system prompt", "Hello")
+    out = capsys.readouterr().out
+    assert "single reply" in out
+
+
+def test_openai_infer_requires_api_key(monkeypatch):
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY is not set"):
+        openai_infer("gpt", [Message("user", "hi")])
+
+
+def test_openai_infer_requires_model(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    with pytest.raises(RuntimeError, match="--model is required"):
+        openai_infer(None, [Message("user", "hi")])
+
+
+def test_openai_infer_success(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.com")
+
+    class FakeResponse:
+        def __init__(self):
+            self.choices = [
+                SimpleNamespace(message=SimpleNamespace(content=" success "))
+            ]
+
+    class FakeClient:
+        def __init__(self, *_, **__):
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **__: FakeResponse())
+            )
+
+    fake_module = SimpleNamespace(OpenAI=FakeClient)
+    monkeypatch.setitem(sys.modules, "openai", fake_module)
+
+    result = openai_infer("gpt", [Message("user", "hi")])
+    assert result == "success"
+
+
+def test_openai_infer_raises_runtime_error(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+
+    class FakeClient:
+        def __init__(self, *_, **__):
+            class FakeChat:
+                def __init__(self):
+                    self.completions = self
+
+                def create(self, **_):
+                    raise RuntimeError("boom")
+
+            self.chat = FakeChat()
+
+    fake_module = SimpleNamespace(OpenAI=FakeClient)
+    monkeypatch.setitem(sys.modules, "openai", fake_module)
+
+    with pytest.raises(RuntimeError, match="OpenAI API error: boom"):
+        openai_infer("gpt", [Message("user", "hi")])
+
+
+def test_ollama_infer_requires_model():
+    with pytest.raises(RuntimeError, match="--model is required"):
+        ollama_infer(None, [Message("user", "hi")])
+
+
+def test_ollama_infer_requires_requests(monkeypatch):
+    monkeypatch.setattr(chatbot, "requests", None)
+    with pytest.raises(RuntimeError, match="requests"):
+        ollama_infer("model", [Message("user", "hi")])
+
+
+def test_ollama_infer_success(monkeypatch):
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeRequests:
+        def __init__(self):
+            self.calls = []
+
+        def post(self, url, data=None, headers=None, timeout=None):
+            self.calls.append(
+                {
+                    "url": url,
+                    "data": data,
+                    "headers": headers,
+                    "timeout": timeout,
+                }
+            )
+            return FakeResponse(
+                {
+                    "choices": [
+                        {
+                            "message": {"content": "hello"},
+                        }
+                    ]
+                }
+            )
+
+    fake_requests = FakeRequests()
+    monkeypatch.setattr(chatbot, "requests", fake_requests)
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama.local")
+
+    result = ollama_infer("model", [Message("user", "hi")])
+    assert result == "hello"
+
+    call = fake_requests.calls[0]
+    assert call["url"].startswith("http://ollama.local")
+    assert call["timeout"] == 120
+
+
+def test_qwen_infer_uses_provider(monkeypatch):
+    class FakeProvider:
+        def __init__(self):
+            self.calls = []
+
+        def chat(self, messages, model_override=None):
+            self.calls.append((messages, model_override))
+            return "qwen says hi"
+
+    monkeypatch.setattr(chatbot, "QwenProvider", FakeProvider)
+
+    result = qwen_infer("qwen-model", [Message("user", "hi")])
+    assert result == "qwen says hi"
+
+
+def test_qwen_provider_requires_api_key(monkeypatch):
+    provider = qwen_provider.QwenProvider()
+    provider.api_key = None
+    with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY is not set"):
+        provider.chat([{"role": "user", "content": "hi"}])
+
+
+def test_qwen_provider_chat_success(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "token")
+    monkeypatch.setenv("MODEL_NAME", "qwen-model")
+    importlib.reload(importlib.import_module("src.config"))
+    module = importlib.reload(qwen_provider)
+    provider = module.QwenProvider()
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"choices": [{"message": {"content": "generated"}}]}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        assert url.endswith("/chat/completions")
+        assert headers["Authorization"] == "Bearer token"
+        assert json["model"] == "qwen-model"
+        assert timeout == 30
+        return FakeResponse()
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    result = provider.chat([{"role": "user", "content": "hi"}])
+    assert result == "generated"
+
+
+def test_config_loads_dotenv(monkeypatch):
+    project_root = Path(__file__).resolve().parents[1]
+    env_path = project_root / ".env"
+    env_path.write_text("OPENROUTER_API_KEY=token\nMODEL_NAME=custom\n")
+    try:
+        if "src.config" in sys.modules:
+            del sys.modules["src.config"]
+        config = importlib.import_module("src.config")
+        importlib.reload(config)
+        assert config.OPENROUTER_API_KEY == "token"
+        assert config.MODEL_NAME == "custom"
+    finally:
+        env_path.unlink()
+        if "src.config" in sys.modules:
+            importlib.reload(importlib.import_module("src.config"))


### PR DESCRIPTION
## Summary
- annotate optional config and requests imports so optional dependencies remain type-safe
- add targeted tests covering CLI helpers and provider integrations, including the Qwen client
- ensure pytest can import the CLI module consistently via a conftest helper

## Testing
- pytest --cov=src --cov=chatbot --cov-report=term-missing
- ruff check
- black --check .
- mypy chatbot.py src --ignore-missing-imports --follow-imports=skip
- bandit -r src chatbot.py

------
https://chatgpt.com/codex/tasks/task_e_68e3e7ac8f748330824540c4a71f3871